### PR TITLE
[fix] sandbox reducer behavior

### DIFF
--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -70,14 +70,16 @@ export function wrapProtoMethod(executor) {
   };
 
   Array.prototype.reduce = function reduce(reducer, init) {
-    if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
-      return executor((function* (array) {
-        let result = init;
-        for (let i = 0; i < array.length; i++) result = yield reducer(result, array[i], i, array);
-        return result;
-      })(this));
-    }
-    return oriArrayReduce.call(this, reducer, init);
+    const hasInit = arguments.length > 1;
+      if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
+        return executor(function* (array) {
+          let result = hasInit? init : array[0];
+          for (let i = hasInit ? 0 : 1; i < array.length; i++) result = yield reducer(result, array[i], i, array);
+          return result;
+        }(this));
+      }
+      if(hasInit) return oriArrayReduce.call(this, reducer, init);
+      return oriArrayReduce.call(this, reducer);
   };
 
   Array.prototype.reduceRight = function reduceRight(reducer, init) {

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -71,15 +71,15 @@ export function wrapProtoMethod(executor) {
 
   Array.prototype.reduce = function reduce(reducer, init) {
     const hasInit = arguments.length > 1;
-      if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
-        return executor(function* (array) {
-          let result = hasInit? init : array[0];
-          for (let i = hasInit ? 0 : 1; i < array.length; i++) result = yield reducer(result, array[i], i, array);
-          return result;
-        }(this));
-      }
-      if(hasInit) return oriArrayReduce.call(this, reducer, init);
-      return oriArrayReduce.call(this, reducer);
+    if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
+      return executor(function* (array) {
+        let result = hasInit ? init : array[0];
+        for (let i = hasInit ? 0 : 1; i < array.length; i++) result = yield reducer(result, array[i], i, array);
+        return result;
+      }(this));
+    }
+    if (hasInit) return oriArrayReduce.call(this, reducer, init);
+    return oriArrayReduce.call(this, reducer);
   };
 
   Array.prototype.reduceRight = function reduceRight(reducer, init) {

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -83,14 +83,19 @@ export function wrapProtoMethod(executor) {
   };
 
   Array.prototype.reduceRight = function reduceRight(reducer, init) {
+    const hasInit = arguments.length > 1;
     if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
-      return executor((function* (array) {
-        let result = init;
-        for (let i = array.length - 1; i !== -1; i--) result = yield reducer(result, array[i], i, array);
+      return executor(function* (array) {
+        let result = hasInit? init : array[array.length - 1];;
+
+        for (let i = hasInit ? array.length - 1: array.length - 2; i !== -1; i--) result = yield reducer(result, array[i], i, array);
+
         return result;
-      })(this));
+      }(this));
     }
-    return oriArrayReduceRight.call(this, reducer, init);
+
+    if(hasInit) return oriArrayReduceRight.call(this, reducer, init);
+    return oriArrayReduceRight.call(this, reducer);
   };
 
   Array.prototype.every = function every(predicate, thisArg) {


### PR DESCRIPTION
The results of arr.reduce(reducer) and arr.reduce(reducer, undefined) are different.